### PR TITLE
add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+[![][travis-img]][travis-url] [![][codecov-img]][codecov-url] [![][slack-img]][slack-url]
+
+[travis-img]: http://img.shields.io/travis/com/JuliaPlots/VennEuler.jl.svg
+[travis-url]: https://travis-ci.com/JuliaPlots/VennEuler.jl
+[codecov-img]: https://codecov.io/gh/JuliaPlots/VennEuler.jl/branch/master/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/JuliaPlots/VennEuler.jl
+[slack-img]: https://img.shields.io/badge/chat-on%20slack-yellow.svg
+[slack-url]: https://julialang.slack.com
+
 VennEuler.jl
 ============
 


### PR DESCRIPTION
@daschw [the link](https://travis-ci.org/JuliaPlots/VennEuler.jl) in this PR to travis reports that VennEuler is not an active repository.  strange, because CI tests ran for the [last PR](https://github.com/JuliaPlots/VennEuler.jl/pull/23) to this repo, which added travis.  may be related to a change in UI--  there is now a "checks" tab on the PR page, instead of a link to travis-ci.org.